### PR TITLE
Cast NSInteger values as long to avoid warnings.

### DIFF
--- a/AFHTTPRequestOperationLogger.m
+++ b/AFHTTPRequestOperationLogger.m
@@ -103,17 +103,17 @@
             case AFLoggerLevelInfo:
             case AFLoggerLevelWarn:
             case AFLoggerLevelError:
-                NSLog(@"[Error] %@ '%@' (%ld): %@", [operation.request HTTPMethod], [[operation.response URL] absoluteString], [operation.response statusCode], operation.error);
+                NSLog(@"[Error] %@ '%@' (%ld): %@", [operation.request HTTPMethod], [[operation.response URL] absoluteString], (long)[operation.response statusCode], operation.error);
             default:
                 break;
         }
     } else {
         switch (self.level) {
             case AFLoggerLevelDebug:
-                NSLog(@"%ld '%@': %@", [operation.response statusCode], [[operation.response URL] absoluteString], operation.responseString);
+                NSLog(@"%ld '%@': %@", (long)[operation.response statusCode], [[operation.response URL] absoluteString], operation.responseString);
                 break;
             case AFLoggerLevelInfo:
-                NSLog(@"%ld '%@'", [operation.response statusCode], [[operation.response URL] absoluteString]);
+                NSLog(@"%ld '%@'", (long)[operation.response statusCode], [[operation.response URL] absoluteString]);
                 break;
             default:
                 break;


### PR DESCRIPTION
From the [64-Bit Transition Guide for Cocoa](http://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/Cocoa64BitGuide/ConvertingExistingApp/ConvertingExistingApp.html):

```
Typically, in 32-bit code you use the %d specifier to format int
values in functions such as printf, NSAssert, and NSLog, and in
methods such as stringWithFormat:. But with NSInteger, which on
64-bit architectures is the same size as long, you need to use the
%ld specifier. Unless you are building 32-bit like 64-bit, these
specifiers generates compiler warnings in 32-bit mode. To avoid
this problem, you can cast the values to long or unsigned long, as
appropriate.
```
