### PR TITLE
remove AFN dependency version limit in podspec.

### DIFF
--- a/AFHTTPRequestOperationLogger.podspec
+++ b/AFHTTPRequestOperationLogger.podspec
@@ -8,5 +8,5 @@ Pod::Spec.new do |s|
   s.source   = { :git => 'https://github.com/AFNetworking/AFHTTPRequestOperationLogger.git', :tag => '0.9.0' }
   s.source_files = 'AFHTTPRequestOperationLogger.{h,m}'
   
-  s.dependency 'AFNetworking', '0.9.0'
+  s.dependency 'AFNetworking'
 end


### PR DESCRIPTION
This limit stopped me to install AFHTTPRequestOperationLogger from CocoaPods if I use AFN 1.0RC in my project.
