### PR TITLE
Add shouldLogOperation block property

### DIFF
--- a/AFHTTPRequestOperationLogger.h
+++ b/AFHTTPRequestOperationLogger.h
@@ -37,6 +37,7 @@ typedef enum {
 }
 
 @property (nonatomic, assign) AFHTTPRequestLoggerLevel level;
+@property (nonatomic, copy) BOOL (^shouldLogOperation)(AFHTTPRequestOperation *operation);
 
 + (AFHTTPRequestOperationLogger *)sharedLogger;
 

--- a/AFHTTPRequestOperationLogger.m
+++ b/AFHTTPRequestOperationLogger.m
@@ -68,7 +68,7 @@
 - (void)HTTPOperationDidStart:(NSNotification *)notification {
   AFHTTPRequestOperation *operation = (AFHTTPRequestOperation *)[notification object];
 
-    if (![operation isKindOfClass:[AFHTTPRequestOperation class]]) {
+    if (![operation isKindOfClass:[AFHTTPRequestOperation class]] || (self.shouldLogOperation && !self.shouldLogOperation(operation))) {
         return;
     }
 
@@ -92,7 +92,7 @@
 - (void)HTTPOperationDidFinish:(NSNotification *)notification {
   AFHTTPRequestOperation *operation = (AFHTTPRequestOperation *)[notification object];
 
-    if (![operation isKindOfClass:[AFHTTPRequestOperation class]]) {
+    if (![operation isKindOfClass:[AFHTTPRequestOperation class]] || (self.shouldLogOperation && !self.shouldLogOperation(operation))) {
         return;
     }
 


### PR DESCRIPTION
This new property gives more control over what is logged. If, for example, you want to keep only responses and filter out requests logs and operations that were cancelled, you could use it this way:

```
    logger.shouldLogOperation = ^BOOL (AFHTTPRequestOperation *operation) {
        BOOL isFinished = [[operation valueForKey:@"state"] intValue] == 3; // AFOperationFinishedState
        BOOL isCancelled = [operation.error.domain isEqualToString:NSURLErrorDomain] && operation.error.code == NSURLErrorCancelled;
        return isFinished && !isCancelled;
    };
```
