### PR TITLE
 allow registering for notifications only once

### DIFF
--- a/AFHTTPRequestOperationLogger.m
+++ b/AFHTTPRequestOperationLogger.m
@@ -29,6 +29,12 @@
 // You can turn on ARC for only AFHTTPRequestOperationLogger files by adding -fobjc-arc to the build phase for each of its files.
 #endif
 
+@interface AFHTTPRequestOperationLogger ()
+
+@property (nonatomic, assign, getter = isLogging) BOOL logging;
+
+@end
+
 @implementation AFHTTPRequestOperationLogger
 @synthesize level = _level;
 @synthesize filterPredicate = _filterPredicate;
@@ -60,12 +66,22 @@
 }
 
 - (void)startLogging {
+    if (self.isLogging) {
+        return;
+    }
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(HTTPOperationDidStart:) name:AFNetworkingOperationDidStartNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(HTTPOperationDidFinish:) name:AFNetworkingOperationDidFinishNotification object:nil];
+
+    self.logging = YES;
 }
 
 - (void)stopLogging {
+    if (self.isLogging == NO) {
+        return;
+    }
     [[NSNotificationCenter defaultCenter] removeObserver:self];
+
+    self.logging = NO;
 }
 
 #pragma mark - NSNotification


### PR DESCRIPTION
if you call startLogging several times log messages appear several times too. of course, the same can be achieved by avoiding to call startLogging several times. I think this solution is more robust to misusage.
