### PR TITLE
Changing AFNetworking version to 2.0.0

### DIFF
--- a/AFHTTPRequestOperationLogger.podspec
+++ b/AFHTTPRequestOperationLogger.podspec
@@ -9,5 +9,6 @@ Pod::Spec.new do |s|
   s.source_files = 'AFHTTPRequestOperationLogger.{h,m}'
   s.requires_arc = true
 
-  s.dependency 'AFNetworking', '~> 1.0'
+  s.dependency 'AFNetworking', '~> 2.0.0'
+  s.ios.deployment_target = '6.0'
 end


### PR DESCRIPTION
I also needed to set the deployment target to 6.0 to avoid compilation errors.
