### PR TITLE
add delegate for logging

### DIFF
--- a/AFHTTPRequestOperationLogger.h
+++ b/AFHTTPRequestOperationLogger.h
@@ -31,15 +31,32 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
   AFLoggerLevelFatal = AFLoggerLevelOff,
 };
 
+
+/**
+ Protocol for delegate to be informed of AFHTTPRequestOperation status. Must implement method -(void)AFHTTPRequestOperationLoggerLog:(NSString*)logString;
+ */
+
+@protocol AFHTTPRequestOperationLoggerDelegate
+
+/**
+ Method called on delegate whenever a request operation should be logged.
+ @param logString the String that will be logged, content depends on AFHTTPRequestLoggerLevel
+ */
+
+@required -(void)AFHTTPRequestOperationLoggerLog:(NSString*)logString;
+
+@end
+
 /**
  `AFHTTPRequestOperationLogger` logs requests and responses made by AFNetworking, with an adjustable level of detail.
  
  Applications should enable the shared instance of `AFHTTPRequestOperationLogger` in `AppDelegate -application:didFinishLaunchingWithOptions:`:
-
-        [[AFHTTPRequestOperationLogger sharedLogger] startLogging];
+ 
+ [[AFHTTPRequestOperationLogger sharedLogger] startLogging];
  
  `AFHTTPRequestOperationLogger` listens for `AFNetworkingOperationDidStartNotification` and `AFNetworkingOperationDidFinishNotification` notifications, which are posted by AFNetworking as request operations are started and finish. For further customization of logging output, users are encouraged to implement desired functionality by listening for these notifications.
  */
+
 @interface AFHTTPRequestOperationLogger : NSObject
 
 /**
@@ -51,6 +68,11 @@ typedef NS_ENUM(NSUInteger, AFHTTPRequestLoggerLevel) {
  Only log operations conforming to the specified predicate, if specified. `nil` by default.
  */
 @property (nonatomic, strong) NSPredicate *filterPredicate;
+
+/**
+ Set a delegate to inform instead of logging to console. `nil` by default.
+ */
+@property (nonatomic, strong) id<AFHTTPRequestOperationLoggerDelegate> delegate;
 
 /**
  Returns the shared logger instance.

--- a/AFHTTPRequestOperationLogger.m
+++ b/AFHTTPRequestOperationLogger.m
@@ -27,6 +27,8 @@
 
 @implementation AFHTTPRequestOperationLogger
 
+@synthesize delegate = _delegate;
+
 + (instancetype)sharedLogger {
     static AFHTTPRequestOperationLogger *_sharedLogger = nil;
     
@@ -85,17 +87,18 @@ static void * AFHTTPRequestOperationStartDate = &AFHTTPRequestOperationStartDate
     if ([operation.request HTTPBody]) {
         body = [[NSString alloc] initWithData:[operation.request HTTPBody] encoding:NSUTF8StringEncoding];
     }
-    
+    NSString* logString;
     switch (self.level) {
         case AFLoggerLevelDebug:
-            NSLog(@"%@ '%@': %@ %@", [operation.request HTTPMethod], [[operation.request URL] absoluteString], [operation.request allHTTPHeaderFields], body);
+            logString = [NSString stringWithFormat:@"%@ '%@': %@ %@", [operation.request HTTPMethod], [[operation.request URL] absoluteString], [operation.request allHTTPHeaderFields], body];
             break;
         case AFLoggerLevelInfo:
-            NSLog(@"%@ '%@'", [operation.request HTTPMethod], [[operation.request URL] absoluteString]);
+            logString = [NSString stringWithFormat:@"%@ '%@'", [operation.request HTTPMethod], [[operation.request URL] absoluteString]];
             break;
         default:
             break;
     }
+    if (!_delegate) NSLog(@"%@", logString); else [_delegate AFHTTPRequestOperationLoggerLog:logString];
 }
 
 - (void)HTTPOperationDidFinish:(NSNotification *)notification {
@@ -111,28 +114,31 @@ static void * AFHTTPRequestOperationStartDate = &AFHTTPRequestOperationStartDate
     
     NSTimeInterval elapsedTime = [[NSDate date] timeIntervalSinceDate:objc_getAssociatedObject(operation, AFHTTPRequestOperationStartDate)];
     
+    NSString* logString;
+    
     if (operation.error) {
         switch (self.level) {
             case AFLoggerLevelDebug:
             case AFLoggerLevelInfo:
             case AFLoggerLevelWarn:
             case AFLoggerLevelError:
-                NSLog(@"[Error] %@ '%@' (%ld) [%.04f s]: %@", [operation.request HTTPMethod], [[operation.response URL] absoluteString], (long)[operation.response statusCode], elapsedTime, operation.error);
+                logString = [NSString stringWithFormat:@"[Error] %@ '%@' (%ld) [%.04f s]: %@", [operation.request HTTPMethod], [[operation.response URL] absoluteString], (long)[operation.response statusCode], elapsedTime, operation.error];
             default:
                 break;
         }
     } else {
         switch (self.level) {
             case AFLoggerLevelDebug:
-                NSLog(@"%ld '%@' [%.04f s]: %@ %@", (long)[operation.response statusCode], [[operation.response URL] absoluteString], elapsedTime, [operation.response allHeaderFields], operation.responseString);
+                logString = [NSString stringWithFormat:@"%ld '%@' [%.04f s]: %@ %@", (long)[operation.response statusCode], [[operation.response URL] absoluteString], elapsedTime, [operation.response allHeaderFields], operation.responseString];
                 break;
             case AFLoggerLevelInfo:
-                NSLog(@"%ld '%@' [%.04f s]", (long)[operation.response statusCode], [[operation.response URL] absoluteString], elapsedTime);
+                logString = [NSString stringWithFormat:@"%ld '%@' [%.04f s]", (long)[operation.response statusCode], [[operation.response URL] absoluteString], elapsedTime];
                 break;
             default:
                 break;
         }
     }
+    if (!_delegate) NSLog(@"%@", logString); else [_delegate AFHTTPRequestOperationLoggerLog:logString];
 }
 
 @end


### PR DESCRIPTION
added the ability to assign a delegate for routing logging output to some other functions easily. I use this to write logging data to a log file for support and debugging.
